### PR TITLE
fix: remove linkedin from footer

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -73,7 +73,6 @@ export const content = {
     social: {
       twitter: 'frocentric_tech',
       instagram: 'frocentric_tech',
-      linkedin: 'company/frocentric-tech'
     },
   },
 };


### PR DESCRIPTION
Removing linkedin from footer as requested by Karen

<img width="373" alt="image" src="https://user-images.githubusercontent.com/11095605/110945990-49872b80-8336-11eb-97ed-33387c352653.png">
